### PR TITLE
Add TCP_SOCKET_FAMILY environment variable

### DIFF
--- a/openshift/bc-registries-deploy.dev.param
+++ b/openshift/bc-registries-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/bcreg-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/bc-registries-deploy.param
+++ b/openshift/bc-registries-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/bcreg-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/bc-registries-deploy.prod.param
+++ b/openshift/bc-registries-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/bcreg-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/bc-registries-deploy.test.param
+++ b/openshift/bc-registries-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/bcreg-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/city-of-surrey-deploy.dev.param
+++ b/openshift/city-of-surrey-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/city-surrey-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/city-of-surrey-deploy.param
+++ b/openshift/city-of-surrey-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/city-surrey-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/city-of-surrey-deploy.prod.param
+++ b/openshift/city-of-surrey-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/city-surrey-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/city-of-surrey-deploy.test.param
+++ b/openshift/city-of-surrey-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/city-surrey-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/fraser-valley-health-authority-deploy.dev.param
+++ b/openshift/fraser-valley-health-authority-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/fraser-valley-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/fraser-valley-health-authority-deploy.param
+++ b/openshift/fraser-valley-health-authority-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/fraser-valley-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/fraser-valley-health-authority-deploy.prod.param
+++ b/openshift/fraser-valley-health-authority-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/fraser-valley-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/fraser-valley-health-authority-deploy.test.param
+++ b/openshift/fraser-valley-health-authority-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/fraser-valley-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/liquor-control-and-licensing-branch-deploy.dev.param
+++ b/openshift/liquor-control-and-licensing-branch-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/liquor-control-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/liquor-control-and-licensing-branch-deploy.param
+++ b/openshift/liquor-control-and-licensing-branch-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/liquor-control-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/liquor-control-and-licensing-branch-deploy.prod.param
+++ b/openshift/liquor-control-and-licensing-branch-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/liquor-control-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/liquor-control-and-licensing-branch-deploy.test.param
+++ b/openshift/liquor-control-and-licensing-branch-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/liquor-control-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-agriculture-deploy.dev.param
+++ b/openshift/ministry-of-agriculture-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/agri-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-agriculture-deploy.param
+++ b/openshift/ministry-of-agriculture-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/agri-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/ministry-of-agriculture-deploy.prod.param
+++ b/openshift/ministry-of-agriculture-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/agri-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-agriculture-deploy.test.param
+++ b/openshift/ministry-of-agriculture-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/agri-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-finance-deploy.dev.param
+++ b/openshift/ministry-of-finance-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/ministry-finance-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-finance-deploy.param
+++ b/openshift/ministry-of-finance-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/ministry-finance-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/ministry-of-finance-deploy.prod.param
+++ b/openshift/ministry-of-finance-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/ministry-finance-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/ministry-of-finance-deploy.test.param
+++ b/openshift/ministry-of-finance-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/ministry-finance-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/templates/agents/bc-registries-deploy.json
+++ b/openshift/templates/agents/bc-registries-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/city-of-surrey-deploy.json
+++ b/openshift/templates/agents/city-of-surrey-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/fraser-valley-health-authority-deploy.json
+++ b/openshift/templates/agents/fraser-valley-health-authority-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/liquor-control-and-licensing-branch-deploy.json
+++ b/openshift/templates/agents/liquor-control-and-licensing-branch-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/ministry-of-agriculture-deploy.json
+++ b/openshift/templates/agents/ministry-of-agriculture-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/ministry-of-finance-deploy.json
+++ b/openshift/templates/agents/ministry-of-finance-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/templates/agents/worksafe-bc-deploy.json
+++ b/openshift/templates/agents/worksafe-bc-deploy.json
@@ -248,6 +248,10 @@
                   {
                     "name": "ENDPOINT_URL",
                     "value": "${ENDPOINT_URL}"
+                  },
+                  {
+                    "name": "TCP_SOCKET_FAMILY",
+                    "value": "${TCP_SOCKET_FAMILY}"
                   }
                 ],
                 "readinessProbe": {
@@ -353,6 +357,13 @@
       "description": "The public domain endpoint for the agent, which is registered on the ledger.",
       "required": true,
       "value": "https://dev-dflow.orgbook.gov.bc.ca"
+    },
+    {
+      "name": "TCP_SOCKET_FAMILY",
+      "displayName": "TCP Socket Family",
+      "description": "The TCP socket version to be used by the agent DNS resolver.",
+      "required": true,
+      "value": "IPV4"
     },
     {
       "name": "CONFIG_ROOT",

--- a/openshift/worksafe-bc-deploy.dev.param
+++ b/openshift/worksafe-bc-deploy.dev.param
@@ -9,6 +9,7 @@
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/worksafe-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/worksafe-bc-deploy.param
+++ b/openshift/worksafe-bc-deploy.param
@@ -9,6 +9,7 @@ IMAGE_NAMESPACE=devex-von-permitify-tools
 TAG_NAME=dev
 APPLICATION_URL=https://dev-dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dev-dflow.orgbook.gov.bc.ca
+TCP_SOCKET_FAMILY=TCPV4
 CONFIG_ROOT=../config/worksafe-agent
 HOST_PORT=8080
 ENVIRONMENT=default

--- a/openshift/worksafe-bc-deploy.prod.param
+++ b/openshift/worksafe-bc-deploy.prod.param
@@ -9,6 +9,7 @@
 TAG_NAME=prod
 APPLICATION_URL=https://demo.orgbook.gov.bc.ca
 ENDPOINT_URL=https://demo.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/worksafe-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default

--- a/openshift/worksafe-bc-deploy.test.param
+++ b/openshift/worksafe-bc-deploy.test.param
@@ -9,6 +9,7 @@
 TAG_NAME=test
 APPLICATION_URL=https://dflow.orgbook.gov.bc.ca
 ENDPOINT_URL=https://dflow.orgbook.gov.bc.ca
+# TCP_SOCKET_FAMILY=TCPV4
 # CONFIG_ROOT=../config/worksafe-agent
 # HOST_PORT=8080
 # ENVIRONMENT=default


### PR DESCRIPTION
Updated OpenShift configurations to include TCP_SOCKET_VERSION environment variable.

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>