### PR TITLE
Use bcreg agent as proxy for get-credential-dependencies API call.

### DIFF
--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -25,11 +25,11 @@ export class TobService {
     let reqURL = '';
 
     // This is required to address limitations with how the agent endpoints are published in Docker
-    if (/^http(s?):\/\/localhost/.test(window.location.href)) {
+    // if (/^http(s?):\/\/localhost/.test(window.location.href)) {
       reqURL = `bcreg/get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
-    } else {
-      reqURL = `${endpoint}/get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
-    }
+    // } else {
+    //   reqURL = `${endpoint}/get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
+    // }
     return this.http.post(reqURL, null, { withCredentials: true });
   }
 


### PR DESCRIPTION
Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>