### PR TITLE
Updated OpenShift build configuration resource limits.

### DIFF
--- a/openshift/templates/agents/agent-build.json
+++ b/openshift/templates/agents/agent-build.json
@@ -43,16 +43,6 @@
             "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
           }
         },
-        "resources": {
-          "requests": {
-            "cpu": "${CPU_REQUEST}",
-            "memory": "${MEMORY_REQUEST}"
-          },
-          "limits": {
-            "cpu": "${CPU_LIMIT}",
-            "memory": "${MEMORY_LIMIT}"
-          }
-        },
         "triggers": [
           {
             "type": "ConfigChange"
@@ -103,34 +93,6 @@
       "description": "The path to the docker file.",
       "required": true,
       "value": "docker/agent/Dockerfile"
-    },
-    {
-      "name": "CPU_LIMIT",
-      "displayName": "Resources CPU Limit",
-      "description": "The resources CPU limit (in cores) for this build.",
-      "required": true,
-      "value": "0"
-    },
-    {
-      "name": "MEMORY_LIMIT",
-      "displayName": "Resources Memory Limit",
-      "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
-      "required": true,
-      "value": "0Mi"
-    },
-    {
-      "name": "CPU_REQUEST",
-      "displayName": "Resources CPU Request",
-      "description": "The resources CPU request (in cores) for this build.",
-      "required": true,
-      "value": "0"
-    },
-    {
-      "name": "MEMORY_REQUEST",
-      "displayName": "Resources Memory Request",
-      "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
-      "required": true,
-      "value": "0Mi"
     }
   ]
 }

--- a/openshift/templates/caddy-runtime/caddy-runtime-build.json
+++ b/openshift/templates/caddy-runtime/caddy-runtime-build.json
@@ -48,16 +48,6 @@
             "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
           }
         },
-        "resources": {
-          "requests": {
-            "cpu": "${CPU_REQUEST}",
-            "memory": "${MEMORY_REQUEST}"
-          },
-          "limits": {
-            "cpu": "${CPU_LIMIT}",
-            "memory": "${MEMORY_LIMIT}"
-          }
-        },
         "triggers": [
           {
             "type": "ConfigChange"
@@ -136,34 +126,6 @@
       "description": "The path to the docker file.",
       "required": true,
       "value": "docker/proxy/Dockerfile"
-    },
-    {
-      "name": "CPU_LIMIT",
-      "displayName": "Resources CPU Limit",
-      "description": "The resources CPU limit (in cores) for this build.",
-      "required": true,
-      "value": "0"
-    },
-    {
-      "name": "MEMORY_LIMIT",
-      "displayName": "Resources Memory Limit",
-      "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
-      "required": true,
-      "value": "0Mi"
-    },
-    {
-      "name": "CPU_REQUEST",
-      "displayName": "Resources CPU Request",
-      "description": "The resources CPU request (in cores) for this build.",
-      "required": true,
-      "value": "0"
-    },
-    {
-      "name": "MEMORY_REQUEST",
-      "displayName": "Resources Memory Request",
-      "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
-      "required": true,
-      "value": "0Mi"
     }
   ]
 }

--- a/openshift/templates/dflow-angular/dflow-angular-build.json
+++ b/openshift/templates/dflow-angular/dflow-angular-build.json
@@ -109,28 +109,28 @@
       "displayName": "Resources CPU Limit",
       "description": "The resources CPU limit (in cores) for this build.",
       "required": true,
-      "value": "0"
+      "value": "1"
     },
     {
       "name": "MEMORY_LIMIT",
       "displayName": "Resources Memory Limit",
       "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
       "required": true,
-      "value": "0Mi"
+      "value": "2Gi"
     },
     {
       "name": "CPU_REQUEST",
       "displayName": "Resources CPU Request",
       "description": "The resources CPU request (in cores) for this build.",
       "required": true,
-      "value": "0"
+      "value": "500m"
     },
     {
       "name": "MEMORY_REQUEST",
       "displayName": "Resources Memory Request",
       "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
       "required": true,
-      "value": "0Mi"
+      "value": "1Gi"
     }
   ]
 }

--- a/openshift/templates/dflow/dflow-build.json
+++ b/openshift/templates/dflow/dflow-build.json
@@ -66,12 +66,6 @@
             "kind": "ImageStreamTag",
             "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
           }
-        },
-        "resources": {
-          "limits": {
-            "cpu": "${CPU_LIMIT}",
-            "memory": "${MEMORY_LIMIT}"
-          }
         }
       }
     }
@@ -132,20 +126,6 @@
       "description": "The tag given to the built image.",
       "required": true,
       "value": "latest"
-    },
-    {
-      "name": "CPU_LIMIT",
-      "displayName": "Resources CPU Limit",
-      "description": "The resources CPU limit (in cores) for this build.",
-      "required": true,
-      "value": "1"
-    },
-    {
-      "name": "MEMORY_LIMIT",
-      "displayName": "Resources Memory Limit",
-      "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
-      "required": true,
-      "value": "1Gi"
     }
   ]
 }


### PR DESCRIPTION
Resource requests and limits were set to default cluster values for most build configurations.
Angular build is resource-hungry: values were set to what seems to result in a successful build, but may need further tweaking in the future.

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>